### PR TITLE
feat: submit uptime proofs for current epoch only

### DIFF
--- a/contracts/validator-manager/Native721TokenStakingManager.sol
+++ b/contracts/validator-manager/Native721TokenStakingManager.sol
@@ -674,12 +674,8 @@ contract Native721TokenStakingManager is
     ) internal override returns (uint64) {
         StakingManagerStorage storage $ = _getStakingManagerStorage();
 
-        if ($._uptimeKeeper != _msgSender()) {
-            revert OwnableUnauthorizedAccount(_msgSender());
-        }
-
         uint64 uptime = _validateUptime(validationID, messageIndex);
-        uint64 epoch = _getEpoch() - 1;
+        uint64 epoch = _getEpoch();
         uint64 dur = $._epochDuration;
 
         PoSValidatorInfo storage validatorInfo = $._posValidatorInfo[validationID];

--- a/contracts/validator-manager/tests/Native721TokenStakingManagerTests.t.sol
+++ b/contracts/validator-manager/tests/Native721TokenStakingManagerTests.t.sol
@@ -199,22 +199,6 @@ contract Native721TokenStakingManagerTest is StakingManagerTest, IERC721Receiver
         app.registerNFTDelegation(validationID, tokens);
     }
 
-    function testSubmitUptimeNonOwner() public {
-        bytes32 validationID = _registerDefaultValidator();
-
-        vm.warp(DEFAULT_REGISTRATION_TIMESTAMP + DEFAULT_EPOCH_DURATION);
-        bytes memory uptimeMessage = ValidatorMessages.packValidationUptimeMessage(validationID, 0);
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                OwnableUpgradeable.OwnableUnauthorizedAccount.selector, DEFAULT_DELEGATOR_ADDRESS
-            )
-        );
-
-        vm.prank(DEFAULT_DELEGATOR_ADDRESS);
-        app.submitUptimeProof(validationID, 0);
-    }
-
     function testSubmitUptimes() public {
         bytes32 validationID = _registerDefaultValidator();
 
@@ -277,7 +261,12 @@ contract Native721TokenStakingManagerTest is StakingManagerTest, IERC721Receiver
         messageIndexes[0] = 0;
         messageIndexes[1] = 1;
 
+        // uptime keeper
         vm.prank(DEFAULT_UPTIME_KEEPER);
+        app.submitUptimeProofs(validationIDs, messageIndexes);
+
+        // any other address
+        vm.prank(DEFAULT_DELEGATOR_ADDRESS);
         app.submitUptimeProofs(validationIDs, messageIndexes);
     }
 
@@ -376,8 +365,10 @@ contract Native721TokenStakingManagerTest is StakingManagerTest, IERC721Receiver
             rewardRecipient: DEFAULT_DELEGATOR_ADDRESS
         });
 
-        vm.warp(DEFAULT_REGISTRATION_TIMESTAMP + DEFAULT_EPOCH_DURATION);
+        vm.warp(DEFAULT_COMPLETION_TIMESTAMP + 1);
         _submitUptime(validationID, DEFAULT_COMPLETION_TIMESTAMP - DEFAULT_REGISTRATION_TIMESTAMP);
+
+        vm.warp(DEFAULT_REGISTRATION_TIMESTAMP + DEFAULT_EPOCH_DURATION);
 
         bytes32[] memory delegationIDs = new bytes32[](1);
         delegationIDs[0] = delegationID;
@@ -415,8 +406,10 @@ contract Native721TokenStakingManagerTest is StakingManagerTest, IERC721Receiver
             rewardRecipient: DEFAULT_DELEGATOR_ADDRESS
         });
 
-        vm.warp(DEFAULT_REGISTRATION_TIMESTAMP + DEFAULT_EPOCH_DURATION);
+        vm.warp(DEFAULT_COMPLETION_TIMESTAMP + 1);
         _submitUptime(validationID, DEFAULT_COMPLETION_TIMESTAMP - DEFAULT_REGISTRATION_TIMESTAMP);
+
+        vm.warp(DEFAULT_REGISTRATION_TIMESTAMP + DEFAULT_EPOCH_DURATION);
 
         bytes32[] memory delegationIDs = new bytes32[](1);
         delegationIDs[0] = delegationID;
@@ -506,8 +499,10 @@ contract Native721TokenStakingManagerTest is StakingManagerTest, IERC721Receiver
             rewardRecipient: DEFAULT_DELEGATOR_ADDRESS
         });
 
-        vm.warp(DEFAULT_REGISTRATION_TIMESTAMP + DEFAULT_EPOCH_DURATION);
+        vm.warp(DEFAULT_COMPLETION_TIMESTAMP + 1);
         _submitUptime(validationID, DEFAULT_COMPLETION_TIMESTAMP - DEFAULT_REGISTRATION_TIMESTAMP);
+
+        vm.warp(DEFAULT_REGISTRATION_TIMESTAMP + DEFAULT_EPOCH_DURATION);
 
         bytes32[] memory delegationIDs = new bytes32[](1);
         delegationIDs[0] = delegationID;
@@ -543,8 +538,10 @@ contract Native721TokenStakingManagerTest is StakingManagerTest, IERC721Receiver
 
         _expectNFTStakeUnlock(DEFAULT_DELEGATOR_ADDRESS, 1);
 
-        vm.warp(DEFAULT_REGISTRATION_TIMESTAMP + DEFAULT_EPOCH_DURATION);
+        vm.warp(DEFAULT_COMPLETION_TIMESTAMP + 1);
         _submitUptime(validationID, DEFAULT_COMPLETION_TIMESTAMP - DEFAULT_REGISTRATION_TIMESTAMP);
+
+        vm.warp(DEFAULT_REGISTRATION_TIMESTAMP + DEFAULT_EPOCH_DURATION);
 
         bytes32[] memory delegationIDs = new bytes32[](1);
         delegationIDs[0] = delegationID;
@@ -600,8 +597,10 @@ contract Native721TokenStakingManagerTest is StakingManagerTest, IERC721Receiver
             rewardRecipient: DEFAULT_DELEGATOR_ADDRESS
         });
 
-        vm.warp(DEFAULT_REGISTRATION_TIMESTAMP + DEFAULT_EPOCH_DURATION);
+        vm.warp(DEFAULT_COMPLETION_TIMESTAMP + 1);
         _submitUptime(validationID, DEFAULT_COMPLETION_TIMESTAMP - DEFAULT_REGISTRATION_TIMESTAMP);
+
+        vm.warp(DEFAULT_REGISTRATION_TIMESTAMP + DEFAULT_EPOCH_DURATION);
 
         bytes32[] memory delegationIDs = new bytes32[](2);
         delegationIDs[0] = delegationID;
@@ -650,8 +649,10 @@ contract Native721TokenStakingManagerTest is StakingManagerTest, IERC721Receiver
             rewardRecipient: DEFAULT_DELEGATOR_ADDRESS
         });
 
-        vm.warp(DEFAULT_REGISTRATION_TIMESTAMP + DEFAULT_EPOCH_DURATION);
+        vm.warp(DEFAULT_COMPLETION_TIMESTAMP + 1);
         _submitUptime(validationID, DEFAULT_COMPLETION_TIMESTAMP - DEFAULT_REGISTRATION_TIMESTAMP);
+
+        vm.warp(DEFAULT_REGISTRATION_TIMESTAMP + DEFAULT_EPOCH_DURATION);
 
         bytes32[] memory delegationIDs = new bytes32[](2);
         delegationIDs[0] = delegationID;

--- a/contracts/validator-manager/tests/StakingManagerTests.t.sol
+++ b/contracts/validator-manager/tests/StakingManagerTests.t.sol
@@ -1185,9 +1185,11 @@ abstract contract StakingManagerTest is ValidatorManagerTest {
         vm.expectEmit(true, true, true, true, address(stakingManager));
         emit UptimeUpdated(validationID, uptime1, 0);
 
-        vm.warp(DEFAULT_REGISTRATION_TIMESTAMP + DEFAULT_EPOCH_DURATION);
+        vm.warp(DEFAULT_COMPLETION_TIMESTAMP + 1);
         vm.prank(DEFAULT_UPTIME_KEEPER);
         stakingManager.submitUptimeProof(validationID, 0);
+
+        vm.warp(DEFAULT_REGISTRATION_TIMESTAMP + DEFAULT_EPOCH_DURATION);
 
         vm.expectEmit(true, true, true, true, address(validatorManager));
         emit InitiatedValidatorRemoval(


### PR DESCRIPTION
## Motivation
- currently, uptime proofs can only be submitted for the _past_ epoch (meant to be done in the 7day window after the epoch ends)
- when validators exit the validator set during the epoch, their uptime proofs get invalidated and it's technically like they'd have been gone all month in terms of rewards
- we currently calculate and send out those rewards manually
- to prevent from people altering their past uptime proofs, this method is restricted to a permissioned wallet. in general, we want to avoid that where possible

## Solution
- the contract registers any uptime proof submitted to it as part of the _current_ epoch
- instead of submitting proofs once after the epoch, we'll do it on a regular basis (eg daily) to cover uptime of validators who may exit during the epoch correctly
- due to this change, past uptime can't be altered anymore, so the permissioned access is not necessary anymore, and was removed

## Considerations
- alternatively we could have added the epoch to submit uptime for as a param of the call. then we couldn't drop the permissioned access though since uptime could be messed with retroactively

## Risk Rating
Low-Medium

## To Do
- add/update unit tests (existing unit tests failing) - done!