### PR TITLE
feat: added recovery method for stuck erc20

### DIFF
--- a/contracts/validator-manager/Native721TokenStakingManager.sol
+++ b/contracts/validator-manager/Native721TokenStakingManager.sol
@@ -359,6 +359,24 @@ contract Native721TokenStakingManager is
     }
 
     /**
+     * @notice Allows the contract owner to recover ERC20 tokens that may have been accidentally sent to the contract.
+     * @dev This function allows the contract owner to recover ERC20 tokens that may have been accidentally sent to the contract.
+     * @param token The address of the ERC20 token to recover.
+     * @param to The address to which the recovered tokens will be sent.
+     * @param amount The amount of tokens to recover.
+     *
+     * Requirements:
+     * - Only the contract owner can call this function.
+     */
+    function recoverERC20(
+        address token,
+        address to,
+        uint256 amount
+    ) external onlyOwner nonReentrant {
+        IERC20(token).transfer(to, amount);
+    }
+
+    /**
      * @notice See {INative721TokenStakingManager-erc721}.
      */
     function erc721() external view returns (IERC721) {


### PR DESCRIPTION
## Motivation
- due to some contract errors, we lost part of the registered rewards, which we needed to replenish by sending erc20 to the contract directly
- it's close to impossible to calculate the exact amount to replenish, and we opted for adding a buffer instead of running into issues when the last people claim
- the byte size of the staking contract is already at the limit, so only small sensible changes are possible

## Solution
- added a simple method to transfer leftover reward tokens used for desaster-recovery out of the contract. limited to contract owner.

## Considerations
- @zjesko proposed to rewrite the _cancelRewards_ method instead. while this would make sense in terms of cleaner code, the added complexity to the existing method and the interface changes would have cost us more bytes
- There's no use case (other than an accident) where native tokens would be transferred to the staking contract, so let's keep this as slim as possible for the moment

## Risk-Rating
Low (simple function, can only be called by admin)

## To Do
- unit tests - done